### PR TITLE
Add a procedural macro to generate mock structs from traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Rust
-/target
+target
 **/*.rs.bk
 Cargo.lock
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["development-tools::testing"]
 edition = "2018"
 
 [dependencies]
+mock-it_codegen = { version = "0.1.0", path = "./mock-it_codegen" }
 
 [dev-dependencies]
 table-test = "0.2.1"

--- a/mock-it_codegen/Cargo.toml
+++ b/mock-it_codegen/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mock-it_codegen"
+version = "0.1.0"
+authors = ["Mcat12 <mark.drobnak@gmail.com>", "nathanielsimard <nathaniel.simard@outlook.com>"]
+description = "Codegen for mock-it"
+repository = "https://github.com/nathanielsimard/mock-it"
+license = "MIT"
+readme="README.md"
+keywords = ["mock", "mocking", "unit-test", "testing"]
+categories = ["development-tools::testing"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "0.15", features = ["full"] }
+quote = "0.6"
+proc-macro2 = "0.4"

--- a/mock-it_codegen/src/lib.rs
+++ b/mock-it_codegen/src/lib.rs
@@ -1,0 +1,159 @@
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, ArgCaptured, FnArg, Ident, Item, ItemTrait, Pat, ReturnType, TraitItem,
+    TraitItemMethod, Type,
+};
+
+/// Generate a mock struct from a trait. The mock struct will be named after the
+/// trait, with "Mock" appended.
+#[proc_macro_attribute]
+pub fn mock_it(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    // Parse the tokens
+    let input: Item = parse_macro_input!(item as Item);
+
+    // Make sure it's a trait
+    let item_trait = match input {
+        Item::Trait(item_trait) => item_trait,
+        _ => panic!("Only traits can be mocked with the mock_it macro"),
+    };
+
+    // Create the mock identifier
+    let trait_ident = &item_trait.ident;
+    let mock_ident = Ident::new(&format!("{}Mock", trait_ident), trait_ident.span());
+
+    // Generate the mock
+    let fields = create_fields(&item_trait);
+    let field_init = create_field_init(&item_trait);
+    let trait_impls = create_trait_impls(&item_trait);
+
+    // Combine and tokenize the final result
+    let output = quote! {
+        #item_trait
+
+        pub struct #mock_ident {
+            #(#fields),*
+        }
+
+        impl #mock_ident {
+            pub fn new() -> Self {
+                #mock_ident {
+                    #(#field_init),*
+                }
+            }
+        }
+
+        impl #trait_ident for #mock_ident {
+            #(#trait_impls)*
+        }
+    };
+
+    output.into()
+}
+
+/// Create the struct fields
+fn create_fields(item_trait: &ItemTrait) -> impl Iterator<Item = TokenStream> + '_ {
+    get_mocks(item_trait).map(|(ident, mock)| {
+        quote! {
+            pub #ident: #mock
+        }
+    })
+}
+
+/// Create the field initializers for the `new` method
+fn create_field_init(item_trait: &ItemTrait) -> impl Iterator<Item = TokenStream> + '_ {
+    get_trait_method_types(item_trait).map(|(ident, _, return_type)| {
+        let default_value = match return_type {
+            Some(return_type) => quote! { <#return_type as core::default::Default>::default() },
+            None => quote! { () },
+        };
+
+        quote! {
+            #ident: mock_it::Mock::new(#default_value)
+        }
+    })
+}
+
+/// Create the trait method implementations
+fn create_trait_impls(item_trait: &ItemTrait) -> impl Iterator<Item = TokenStream> + '_ {
+    get_trait_methods(item_trait).map(|method| {
+        let (ident, args, _) = get_method_types(method);
+        let arg_names: Vec<Ident> = args
+            .into_iter()
+            .map(|arg| match arg.pat {
+                Pat::Ident(ref inner) => inner.ident.clone(),
+                _ => panic!("unknown argument pattern"),
+            })
+            .collect();
+        let signature = &method.sig;
+
+        quote! {
+            #signature {
+                self.#ident.called((#(#arg_names),*))
+            }
+        }
+    })
+}
+
+/// Get the mock types for each method on the trait
+fn get_mocks(item_trait: &ItemTrait) -> impl Iterator<Item = (Ident, TokenStream)> + '_ {
+    get_trait_method_types(item_trait)
+        .map(|(ident, args, return_type)| (ident, get_mock(args, return_type)))
+}
+
+/// Get the mock type for the arguments and return type combination
+fn get_mock(args: Vec<&ArgCaptured>, return_type: Option<&Box<Type>>) -> TokenStream {
+    let arg_types: Vec<&Type> = args.into_iter().map(|arg| &arg.ty).collect();
+    let return_tokens = match return_type {
+        Some(return_type) => quote! { #return_type },
+        None => quote! { () },
+    };
+
+    quote! {
+        mock_it::Mock<(#(#arg_types),*), #return_tokens>
+    }
+}
+
+/// Get the identifier, arguments, and return type for each method in the trait
+fn get_trait_method_types(
+    item_trait: &ItemTrait,
+) -> impl Iterator<Item = (Ident, Vec<&ArgCaptured>, Option<&Box<Type>>)> {
+    get_trait_methods(item_trait).map(get_method_types)
+}
+
+/// Get the method's identifier, arguments, and return type
+fn get_method_types(method: &TraitItemMethod) -> (Ident, Vec<&ArgCaptured>, Option<&Box<Type>>) {
+    let ident = method.sig.ident.clone();
+    let args: Vec<&ArgCaptured> = method
+        .sig
+        .decl
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            FnArg::Captured(inner) => Some(inner),
+            _ => None,
+        })
+        .collect();
+    let return_type = match method.sig.decl.output {
+        ReturnType::Default => None,
+        ReturnType::Type(_, ref return_type) => Some(return_type),
+    };
+
+    (ident, args, return_type)
+}
+
+/// Get the methods for the given trait
+fn get_trait_methods(item_trait: &ItemTrait) -> impl Iterator<Item = &TraitItemMethod> {
+    item_trait.items.iter().filter_map(|item| {
+        if let TraitItem::Method(item_method) = item {
+            Some(item_method)
+        } else {
+            None
+        }
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #[macro_use]
 extern crate table_test;
 
+pub use mock_it_codegen::mock_it;
+
 pub use crate::matcher::*;
 pub use crate::mock::*;
 pub use crate::validator::verify;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -5,9 +5,6 @@ pub struct Rule<I, O> {
 
 impl<I, O> Rule<I, O> {
     pub fn new(input: I, output: O) -> Rule<I, O> {
-        Rule {
-            input,
-            output,
-        }
+        Rule { input, output }
     }
 }

--- a/tests/proc_macro.rs
+++ b/tests/proc_macro.rs
@@ -1,0 +1,51 @@
+use mock_it::{mock_it, verify};
+
+#[mock_it]
+trait MyTrait {
+    fn do_something(&self, arg1: String, arg2: usize) -> bool;
+    fn no_return(&self, arg1: usize);
+    fn no_args(&self) -> String;
+}
+
+/// The mock has a `new` method which initializes each mock with a default value
+/// using `Default`
+#[test]
+fn mock_initializes_with_default() {
+    let mock = MyTraitMock::new();
+    let args = ("".to_string(), 0);
+    let output = mock.do_something.called(args);
+
+    assert_eq!(output, bool::default());
+}
+
+/// The mock implements the trait
+#[test]
+fn mock_implements_trait() {
+    let _trait_obj: &MyTrait = &MyTraitMock::new();
+}
+
+/// The mock records calls to the trait methods
+#[test]
+fn mock_is_called() {
+    let mock = MyTraitMock::new();
+
+    mock.do_something("test".to_string(), 42);
+
+    assert!(verify(
+        mock.do_something.was_called_with(("test".to_string(), 42))
+    ));
+}
+
+/// The mock uses the provided inputs if given. Generally, this test makes sure
+/// that the mock behaves the same as handwritten mocks.
+#[test]
+fn mock_respects_given() {
+    let mock = MyTraitMock::new();
+
+    mock.do_something
+        .given(("test".to_string(), 42))
+        .will_return(true);
+
+    assert_ne!(mock.do_something("test 2".to_string(), 42), true);
+    assert_eq!(mock.do_something("test".to_string(), 42), true);
+}


### PR DESCRIPTION
By annotating a trait with `#[mock_it]`, a mock struct is generated which implements the trait while using `Mock`s.

This is a first draft of the macro, and only supports traits without non-self references in the method signatures (no `&str`). The return type has to also implement `Default`. The rest of the traits needed by `Mock` (`Clone`, `PartialEq`) must be implemented by the respective input and output types.

**Example**
Given:
```rust
#[mock_it]
trait MyTrait {
    fn do_something(&self, arg1: String, arg2: usize) -> bool;
    fn no_return(&self, arg1: usize);
    fn no_args(&self) -> String;
}
```

Expanded (via `cargo expand`):
```rust
trait MyTrait {
    fn do_something(&self, arg1: String, arg2: usize) -> bool;
    fn no_return(&self, arg1: usize);
    fn no_args(&self) -> String;
}
pub struct MyTraitMock {
    pub do_something: mock_it::Mock<(String, usize), bool>,
    pub no_return: mock_it::Mock<(usize), ()>,
    pub no_args: mock_it::Mock<(), String>,
}
impl MyTraitMock {
    pub fn new() -> Self {
        MyTraitMock {
            do_something: mock_it::Mock::new(<bool as core::default::Default>::default()),
            no_return: mock_it::Mock::new(()),
            no_args: mock_it::Mock::new(<String as core::default::Default>::default()),
        }
    }
}
impl MyTrait for MyTraitMock {
    fn do_something(&self, arg1: String, arg2: usize) -> bool {
        self.do_something.called((arg1, arg2))
    }
    fn no_return(&self, arg1: usize) {
        self.no_return.called((arg1))
    }
    fn no_args(&self) -> String {
        self.no_args.called(())
    }
}
```